### PR TITLE
Add missing document seperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing document seperator in ec2nodeclass and nodepools templates.
+
 ## [0.2.0] - 2025-07-09
 
 ### Changed

--- a/helm/karpenter-nodepools/templates/ec2nodeclass.yaml
+++ b/helm/karpenter-nodepools/templates/ec2nodeclass.yaml
@@ -1,4 +1,5 @@
 {{- range $name, $value := .Values.nodePools }}
+---
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:

--- a/helm/karpenter-nodepools/templates/nodepools.yaml
+++ b/helm/karpenter-nodepools/templates/nodepools.yaml
@@ -1,4 +1,5 @@
 {{- range $name, $value := .Values.nodePools }}
+---
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Adds a missing document seperator in the ec2nodeclass and nodepools templates.

### Testing

Description on how karpenter-nodepools can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for karpenter-nodepools installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
